### PR TITLE
feat/main app dynamic import tracking

### DIFF
--- a/main-app/dist/main.js
+++ b/main-app/dist/main.js
@@ -4,7 +4,7 @@
 /***/ 809:
 /***/ ((__unused_webpack_module, __unused_webpack_exports, __webpack_require__) => {
 
-__webpack_require__.e(/* import() */ "src_App_ts").then(__webpack_require__.bind(__webpack_require__, 729));
+__webpack_require__.e(/* import() */ "src_App_ts").then(__webpack_require__.bind(__webpack_require__, 276));
 
 /***/ })
 

--- a/main-app/dist/src_App_ts.js
+++ b/main-app/dist/src_App_ts.js
@@ -1,29 +1,12 @@
 "use strict";
 (self["webpackChunkhost"] = self["webpackChunkhost"] || []).push([["src_App_ts"],{
 
-/***/ 729:
+/***/ 276:
 /***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
 
 // ESM COMPAT FLAG
 __webpack_require__.r(__webpack_exports__);
 
-;// CONCATENATED MODULE: ./tracking/index.ts
-function initCustomTracking() {
-  return new Promise(function (resolve) {
-    // setup some listeners
-    document.addEventListener("visibilitychange", function () {
-      if (document.hidden) {
-        console.log("Browser tab is hidden");
-      } else {
-        console.log("Browser tab is visible");
-      }
-    }); // perform some registration logic
-
-    setTimeout(function () {
-      resolve();
-    }, 1000);
-  });
-}
 // EXTERNAL MODULE: ./node_modules/style-loader/dist/runtime/injectStylesIntoStyleTag.js
 var injectStylesIntoStyleTag = __webpack_require__(379);
 var injectStylesIntoStyleTag_default = /*#__PURE__*/__webpack_require__.n(injectStylesIntoStyleTag);
@@ -75,12 +58,14 @@ var update = injectStylesIntoStyleTag_default()(cjs_js_src/* default */.Z, optio
 
 ;// CONCATENATED MODULE: ./src/App.ts
 
-
-initCustomTracking().then(function () {
-  console.log("tracking is on");
-  var p = document.createElement("p");
-  p.innerText = "we have tracking";
-  document.querySelector("#app").appendChild(p);
+__webpack_require__.e(/* import() */ "tracking_index_ts").then(__webpack_require__.bind(__webpack_require__, 284)).then(function (_ref) {
+  var initCustomTracking = _ref.initCustomTracking;
+  initCustomTracking().then(function () {
+    console.log("tracking is on");
+    var p = document.createElement("p");
+    p.innerText = "we have tracking";
+    document.querySelector("#app").appendChild(p);
+  });
 });
 
 /***/ }),

--- a/main-app/src/App.ts
+++ b/main-app/src/App.ts
@@ -1,9 +1,10 @@
-import { initCustomTracking } from "@tracking";
 import "./index.css";
 
-initCustomTracking().then(() => {
-  console.log("tracking is on");
-  const p = document.createElement("p");
-  p.innerText = "we have tracking";
-  document.querySelector("#app").appendChild(p);
+import("@tracking").then(({ initCustomTracking }) => {
+  initCustomTracking().then(() => {
+    console.log("tracking is on");
+    const p = document.createElement("p");
+    p.innerText = "we have tracking";
+    document.querySelector("#app").appendChild(p);
+  });
 });


### PR DESCRIPTION
# Build output commentary
In the `/dist` folder we have a module chunk coresponding to the  `src/App.ts` file. In it we can see that webpack concatenates the tracking module, since it was a static import. This means that we have a code duplication issue, since the tracking code is also bundled separately as well into the `tracking_index_ts.js` file. It needs a separate bundle in order to be able to federate it. 

If we were to change that static import, as to how I've done on this PR, it will not concatenate it anymore, and instead use the bundle already prepared for federation. That last phrase is a bit misleading, because webpack would've created that separate `tracking_index_ts.js` even if we just dynamically imported the module and not expose it for federation. 

It's good, though, that webpack knows to use the same module bundle for both use-cases.